### PR TITLE
prevent gulp breaking on sass errors

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,7 @@ const minify = require('gulp-minify-css');
 const sass = require('gulp-sass');
 const autoprefixer = require('gulp-autoprefixer');
 const notify = require('gulp-notify');
+const plumber = require('gulp-plumber');
 
 gulp.task('build', ['fonts', 'scripts:prod', 'styles:prod', 'images']);
 
@@ -77,7 +78,8 @@ function styles(debug) {
     .pipe(globbing({
         extensions: ['.scss']
     }))
-    .pipe(sass())
+    .pipe(plumber())
+    .pipe(sass().on('error', sass.logError))
     .pipe(autoprefixer({
         browsers: ['last 2 versions'],
         cascade: false

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-imagemin": "^3.1.1",
     "gulp-minify-css": "^1.2.4",
     "gulp-notify": "^2.2.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-sass": "^2.0.4",
     "gulp-size": "^2.1.0",
     "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
plumber prevents the gulp stream from breaking on errors